### PR TITLE
datapoints(): Avoid bogus "&_=" api parameter and escape user/d

### DIFF
--- a/gdc.html
+++ b/gdc.html
@@ -47,9 +47,17 @@
         qs.push(s);
       }
       qs.forEach(function(d){
-        gets.push($.getJSON(
-          site + '?format=json&action=userdailycontribs&user='+ user +'&daysago='+ d +'&callback=?',
-          function(data, textStatus, jqXHR) {
+        gets.push($.ajax({
+            url: site,
+            data: {
+              format: 'json',
+              action: 'userdailycontribs',
+              user: user,
+              daysago: d
+            },
+            dataType: 'jsonp',
+            cache: true
+          }).done(function(data, textStatus, jqXHR) {
             if ( data.userdailycontribs.id != 0 ) {
               ret[d] = [data, textStatus, jqXHR];
             }


### PR DESCRIPTION
- Passing `cache: true` will make jQuery not pass the bogus `&_=123` parameter that is causing a warning.
- Convert to `$.ajax` syntax since $.getJSON does not have options object for `cache`.
- Use "data" options so that `user` and `d` are properly encoded for the url.
